### PR TITLE
Make subscription management admin-only by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,19 @@ Once you've got a subscription, go to the admin panel of the forum where this pl
 
 ### Who has access
 
+#### Admins
 Admins can do everything, including:
 
 - Authorize a supplier
 - See subscriptions
 - See all notices (including dismissed and expired)
 
-By default moderators can
-- See subscriptions
-- See active notices
+#### Moderators
+By default moderators cannot do or see anything subscription related and the plugin interface is hidden from them.
 
-You can allow moderators to authorize a supplier, allowing the forum to use a subscription the moderator has with the supplier, if you enable the site setting `subscription client allow moderator supplier authorization`.
+Enable the site setting `subscription client allow moderator subscription management` to let moderators see subscriptions and active subscription notices.
+
+Enable the site setting `subscription client allow moderator supplier authorization` to allow moderators to authorize a supplier, allowing the forum to use a subscription the moderator has with the supplier.
 
 ### Notices
 

--- a/app/controllers/subscription_client/admin_controller.rb
+++ b/app/controllers/subscription_client/admin_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-class SubscriptionClient::AdminController < Admin::AdminController
+class SubscriptionClient::AdminController < ApplicationController
+  requires_login
+  before_action :ensure_can_manage_subscriptions
+
   def index
     respond_to do |format|
       format.html do
@@ -13,5 +16,9 @@ class SubscriptionClient::AdminController < Admin::AdminController
         )
       end
     end
+  end
+
+  def ensure_can_manage_subscriptions
+    Guardian.new(current_user).ensure_can_manage_subscriptions!
   end
 end

--- a/app/controllers/subscription_client/suppliers_controller.rb
+++ b/app/controllers/subscription_client/suppliers_controller.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class SubscriptionClient::SuppliersController < SubscriptionClient::AdminController
-  before_action :ensure_access
+  before_action :ensure_can_manage_suppliers
   skip_before_action :check_xhr, :preload_json, :verify_authenticity_token, only: [:authorize, :authorize_callback]
   before_action :find_supplier, only: [:authorize, :destroy]
 
   def index
-    render_serialized(SubscriptionClientSupplier.all, ::SubscriptionClientSupplierSerializer, root: false)
+    render_serialized(SubscriptionClientSupplier.all, ::SubscriptionClientSupplierSerializer, root: "suppliers")
   end
 
   def authorize
@@ -53,7 +53,7 @@ class SubscriptionClient::SuppliersController < SubscriptionClient::AdminControl
     raise Discourse::InvalidParameters.new(:supplier_id) unless @supplier
   end
 
-  def ensure_access
-    ensure_admin unless SiteSetting.subscription_client_allow_moderator_supplier_authorization
+  def ensure_can_manage_suppliers
+    Guardian.new(current_user).ensure_can_manage_suppliers!
   end
 end

--- a/app/models/subscription_client_notice.rb
+++ b/app/models/subscription_client_notice.rb
@@ -127,7 +127,8 @@ class SubscriptionClientNotice < ActiveRecord::Base
     payload = {
       visible_notice_count: list(visible: true).count
     }
-    MessageBus.publish("/subscription_client_user", payload, group_ids: [Group::AUTO_GROUPS[:staff]])
+    group_id_key = SiteSetting.subscription_client_allow_moderator_subscription_management ? :staff : :admins
+    MessageBus.publish("/subscription_client_user", payload, group_ids: [Group::AUTO_GROUPS[group_id_key.to_sym]])
   end
 
   def self.list(notice_type: nil, notice_subject_type: nil, notice_subject_id: nil, title: nil, include_all: false, visible: false, page: nil, page_limit: 30)

--- a/app/models/subscription_client_supplier.rb
+++ b/app/models/subscription_client_supplier.rb
@@ -29,7 +29,8 @@ class SubscriptionClientSupplier < ActiveRecord::Base
 
   def self.publish_authorized_supplier_count
     payload = { authorized_supplier_count: authorized.count }
-    MessageBus.publish("/subscription_client", payload, group_ids: [Group::AUTO_GROUPS[:staff]])
+    group_id_key = SiteSetting.subscription_client_allow_moderator_subscription_management ? :staff : :admins
+    MessageBus.publish("/subscription_client", payload, group_ids: [Group::AUTO_GROUPS[group_id_key.to_sym]])
   end
 end
 

--- a/assets/javascripts/discourse/connectors/admin-menu/subscription-client-nav-button.hbs
+++ b/assets/javascripts/discourse/connectors/admin-menu/subscription-client-nav-button.hbs
@@ -1,6 +1,0 @@
-{{#if currentUser.admin}}
-
-  {{#if SubscriptionClientErrorNotice}}
-    {{d-icon "exclaimation-circle"}}
-  {{/if}}
-{{/if}}

--- a/assets/javascripts/discourse/initializers/subscription-client-initializer.js.es6
+++ b/assets/javascripts/discourse/initializers/subscription-client-initializer.js.es6
@@ -29,7 +29,7 @@ export default {
     });
 
     const allowModSupplierAuth =
-      siteSettings.subscription_client_allow_moderator_supplier_authorization;
+      siteSettings.subscription_client_allow_moderator_supplier_management;
     const canAccessSubscriptionSuppliers =
       user.admin || (user.moderator && allowModSupplierAuth);
     User.currentProp(

--- a/assets/javascripts/discourse/initializers/subscription-client-initializer.js.es6
+++ b/assets/javascripts/discourse/initializers/subscription-client-initializer.js.es6
@@ -12,79 +12,88 @@ export default {
     const user = container.lookup("current-user:main");
     const siteSettings = container.lookup("site-settings:main");
 
-    if (user && user.staff && siteSettings.subscription_client_enabled) {
-      const bus = container.lookup("message-bus:main");
-
-      bus.subscribe("/subscription_client_user", (data) => {
-        if (isPresent(data.visible_notice_count)) {
-          user.set("subscription_notice_count", data.visible_notice_count);
-        }
-      });
-
-      const allowModSupplierAuth =
-        siteSettings.subscription_client_allow_moderator_supplier_authorization;
-      const canAccessSubscriptionSuppliers =
-        user.admin || (user.moderator && allowModSupplierAuth);
-      User.currentProp(
-        "canAccessSubscriptionSuppliers",
-        canAccessSubscriptionSuppliers
-      );
-
-      let subscriptionNoticeBadge = function () {
-        if (user && user.subscription_notice_count) {
-          return h(
-            "div.badge-notification.subscription-notice",
-            {
-              attributes: {
-                title: I18n.t(
-                  "admin.subscription_client.notifications.subscription_notice_count"
-                ),
-              },
-            },
-            user.subscription_notice_count
-          );
-        }
-      };
-
-      withPluginApi("0.8.32", (api) => {
-        api.reopenWidget("header-dropdown", {
-          html(attrs) {
-            if (attrs.title === "hamburger_menu" && user.staff) {
-              let coreContents = attrs.contents;
-              attrs.contents = function () {
-                return [
-                  coreContents.apply(this, arguments),
-                  subscriptionNoticeBadge.apply(this, arguments),
-                ];
-              };
-              return this._super(attrs);
-            } else {
-              return this._super(attrs);
-            }
-          },
-        });
-
-        api.decorateWidget("hamburger-menu:generalLinks", () => {
-          return [
-            {
-              route: "adminPlugins.subscriptionClient.subscriptions",
-              className: "subscription-notices",
-              label: "admin.subscription_client.title",
-              badgeCount: "subscription_notice_count",
-              badgeClass: "subscription-notice",
-            },
-          ];
-        });
-
-        api.modifyClass("component:site-header", {
-          pluginId: "subscription-client",
-
-          @observes("currentUser.subscription_notice_count")
-          subscriptionClientNoticeCountChanged() {
-            this.queueRerender();
-          },
-        });
-      });
+    if (
+      !siteSettings.subscription_client_enabled ||
+      !user ||
+      !user.can_manage_subscriptions
+    ) {
+      return;
     }
+
+    const bus = container.lookup("message-bus:main");
+
+    bus.subscribe("/subscription_client_user", (data) => {
+      if (isPresent(data.visible_notice_count)) {
+        user.set("subscription_notice_count", data.visible_notice_count);
+      }
+    });
+
+    const allowModSupplierAuth =
+      siteSettings.subscription_client_allow_moderator_supplier_authorization;
+    const canAccessSubscriptionSuppliers =
+      user.admin || (user.moderator && allowModSupplierAuth);
+    User.currentProp(
+      "canAccessSubscriptionSuppliers",
+      canAccessSubscriptionSuppliers
+    );
+
+    let subscriptionNoticeBadge = function () {
+      if (user && user.subscription_notice_count) {
+        return h(
+          "div.badge-notification.subscription-notice",
+          {
+            attributes: {
+              title: I18n.t(
+                "admin.subscription_client.notifications.subscription_notice_count"
+              ),
+            },
+          },
+          user.subscription_notice_count
+        );
+      }
+    };
+
+    withPluginApi("0.8.32", (api) => {
+      api.reopenWidget("header-dropdown", {
+        html(attrs) {
+          if (
+            attrs.title === "hamburger_menu" &&
+            user.can_manage_subscriptions
+          ) {
+            let coreContents = attrs.contents;
+            attrs.contents = function () {
+              return [
+                coreContents.apply(this, arguments),
+                subscriptionNoticeBadge.apply(this, arguments),
+              ];
+            };
+            return this._super(attrs);
+          } else {
+            return this._super(attrs);
+          }
+        },
+      });
+
+      api.decorateWidget("hamburger-menu:generalLinks", () => {
+        return [
+          {
+            route: "adminPlugins.subscriptionClient.subscriptions",
+            className: "subscription-notices",
+            label: "admin.subscription_client.title",
+            badgeCount: "subscription_notice_count",
+            badgeClass: "subscription-notice",
+          },
+        ];
+      });
+
+      api.modifyClass("component:site-header", {
+        pluginId: "subscription-client",
+
+        @observes("currentUser.subscription_notice_count")
+        subscriptionClientNoticeCountChanged() {
+          this.queueRerender();
+        },
+      });
+    });
   },
 };

--- a/assets/javascripts/discourse/routes/admin-plugins-subscription-client-suppliers.js.es6
+++ b/assets/javascripts/discourse/routes/admin-plugins-subscription-client-suppliers.js.es6
@@ -9,7 +9,7 @@ export default DiscourseRoute.extend({
   },
 
   setupController(controller, model) {
-    const suppliers = model.map((supplier) => {
+    const suppliers = model.suppliers.map((supplier) => {
       if (supplier.user) {
         supplier.user = User.create(supplier.user);
       }

--- a/assets/javascripts/discourse/templates/admin-plugins-subscription-client.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-subscription-client.hbs
@@ -1,6 +1,6 @@
 {{#admin-nav}}
   {{nav-item route="adminPlugins.subscriptionClient.subscriptions" label="admin.subscription_client.subscriptions.nav_label"}}
-  {{#if currentUser.admin}}
+  {{#if currentUser.canAccessSubscriptionSuppliers}}
     {{nav-item route="adminPlugins.subscriptionClient.suppliers" label="admin.subscription_client.suppliers.nav_label" class="subscription-client-suppliers-nav"}}
   {{/if}}
   <li>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -33,5 +33,6 @@ en:
     subscription_client_enabled: "Enable the subscription client."
     subscription_client_verbose_logs: "Enable verbose logs for the subscription client."
     subscription_client_warning_notices_on_dashboard: "Show warning notices about subscriptions on the admin dashboard."
+    subscription_client_allow_moderator_subscription_management: "Allow moderators to manage subscriptions."
     subscription_client_allow_moderator_supplier_authorization: "Allow moderators to authorize subscription suppliers."
     subscription_client_request_plugin_statuses: Request the status of plugins from discourse.pluginmanager.org.

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -34,5 +34,7 @@ en:
     subscription_client_verbose_logs: "Enable verbose logs for the subscription client."
     subscription_client_warning_notices_on_dashboard: "Show warning notices about subscriptions on the admin dashboard."
     subscription_client_allow_moderator_subscription_management: "Allow moderators to manage subscriptions."
-    subscription_client_allow_moderator_supplier_authorization: "Allow moderators to authorize subscription suppliers."
+    subscription_client_allow_moderator_supplier_management: "Allow moderators to manage subscription suppliers."
     subscription_client_request_plugin_statuses: Request the status of plugins from discourse.pluginmanager.org.
+    errors:
+      allow_moderator_subscription_management_not_enabled: "Allow moderator subscription management must be enabled."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,8 @@ plugins:
     default: false
   subscription_client_warning_notices_on_dashboard:
     default: true
+  subscription_client_allow_moderator_subscription_management:
+    default: false
   subscription_client_allow_moderator_supplier_authorization:
     default: false
     client: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,9 +8,10 @@ plugins:
     default: true
   subscription_client_allow_moderator_subscription_management:
     default: false
-  subscription_client_allow_moderator_supplier_authorization:
+  subscription_client_allow_moderator_supplier_management:
     default: false
     client: true
+    validator: "AllowModeratorSupplierManagementValidator"
   subscription_client_request_plugin_statuses:
     default: false
     hidden: true

--- a/extensions/admin_plugins_controller.rb
+++ b/extensions/admin_plugins_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module AdminPluginsControllerExtension
+
+  def index
+    plugins = Discourse.visible_plugins
+
+    if !guardian.can_manage_subscriptions?
+      plugins = plugins.select { |p| p.name != "discourse-subscription-client" }
+    end
+
+    render_serialized(plugins, AdminPluginSerializer, root: 'plugins')
+  end
+
+end

--- a/lib/validators/allow_moderator_supplier_management.rb
+++ b/lib/validators/allow_moderator_supplier_management.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AllowModeratorSupplierManagementValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(val)
+    return true if val == "f"
+    SiteSetting.subscription_client_allow_moderator_subscription_management
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.allow_moderator_subscription_management_not_enabled")
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -11,6 +11,8 @@ enabled_site_setting :subscription_client_enabled
 add_admin_route "admin.subscription_client.title", "subscriptionClient"
 register_svg_icon "far-building"
 
+load File.expand_path("../lib/validators/allow_moderator_supplier_management.rb", __FILE__)
+
 after_initialize do
   %w[
     ../lib/subscription_client/engine.rb
@@ -49,8 +51,17 @@ after_initialize do
     return false unless SiteSetting.subscription_client_enabled
 
     is_admin? || (
-      SiteSetting.subscription_client_allow_moderator_subscription_management &&
-      is_staff?
+      is_staff? &&
+      SiteSetting.subscription_client_allow_moderator_subscription_management
+    )
+  end
+
+  add_to_class(:guardian, :can_manage_suppliers?) do
+    return false unless SiteSetting.subscription_client_enabled && can_manage_subscriptions?
+
+    is_admin? || (
+      is_staff? &&
+      SiteSetting.subscription_client_allow_moderator_supplier_management
     )
   end
 

--- a/spec/requests/admin/plugins_controller_spec.rb
+++ b/spec/requests/admin/plugins_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require_relative '../../plugin_helper'
+
+describe Admin::PluginsController do
+  fab!(:moderator) { Fabricate(:user, moderator: true) }
+  fab!(:admin) { Fabricate(:user, admin: true) }
+
+  context "with moderator" do
+    before do
+      sign_in(moderator)
+    end
+
+    context "when cannot manage subscriptions" do
+      before do
+        SiteSetting.subscription_client_allow_moderator_subscription_management = false
+      end
+
+      it "does not serialize the plugin" do
+        get "/admin/plugins.json"
+        expect(response.status).to eq(200)
+        expect(response.parsed_body['plugins'].select { |p| p['id'] == "discourse-subscription-client" }.size).to eq(0)
+      end
+    end
+
+    context "when can manage subscriptions" do
+      before do
+        SiteSetting.subscription_client_allow_moderator_subscription_management = true
+      end
+
+      it "serializes the plugin" do
+        get "/admin/plugins.json"
+        expect(response.status).to eq(200)
+        expect(response.parsed_body['plugins'].select { |p| p['id'] == "discourse-subscription-client" }.size).to eq(1)
+      end
+    end
+  end
+
+  context "with admin" do
+    before do
+      sign_in(admin)
+    end
+
+    it "serializes the plugin" do
+      get "/admin/plugins.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body['plugins'].select { |p| p['id'] == "discourse-subscription-client" }.size).to eq(1)
+    end
+  end
+end

--- a/spec/requests/subscription_client/admin_controller_spec.rb
+++ b/spec/requests/subscription_client/admin_controller_spec.rb
@@ -2,18 +2,45 @@
 require_relative '../../plugin_helper'
 
 describe SubscriptionClient::AdminController do
-  fab!(:user) { Fabricate(:user, admin: true) }
-  fab!(:supplier) { Fabricate(:subscription_client_supplier, api_key: Fabricate(:subscription_client_user_api_key), authorized_at: Time.now, user: user) }
+  fab!(:admin) { Fabricate(:user, admin: true) }
+  fab!(:moderator) { Fabricate(:user, moderator: true) }
+  fab!(:supplier) { Fabricate(:subscription_client_supplier, api_key: Fabricate(:subscription_client_user_api_key), authorized_at: Time.now, user: admin) }
   fab!(:resource) { Fabricate(:subscription_client_resource, supplier: supplier) }
 
-  before do
-    sign_in(user)
+  context "with admin" do
+    before do
+      sign_in(admin)
+    end
+
+    it "returns the authorized supplier count and resource count" do
+      get "/admin/plugins/subscription-client.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body['authorized_supplier_count']).to eq(1)
+      expect(response.parsed_body['resource_count']).to eq(1)
+    end
   end
 
-  it "#index" do
-    get "/admin/plugins/subscription-client.json"
-    expect(response.status).to eq(200)
-    expect(response.parsed_body['authorized_supplier_count']).to eq(1)
-    expect(response.parsed_body['resource_count']).to eq(1)
+  context "with moderator" do
+    before do
+      sign_in(moderator)
+    end
+
+    it "doesnt allow access" do
+      get "/admin/plugins/subscription-client.json"
+      expect(response.status).to eq(403)
+    end
+
+    context "with subscription_client_allow_moderator_supplier_management enabled" do
+      before do
+        SiteSetting.subscription_client_allow_moderator_subscription_management = true
+      end
+
+      it "returns the authorized supplier count and resource count" do
+        get "/admin/plugins/subscription-client.json"
+        expect(response.status).to eq(200)
+        expect(response.parsed_body['authorized_supplier_count']).to eq(1)
+        expect(response.parsed_body['resource_count']).to eq(1)
+      end
+    end
   end
 end

--- a/spec/requests/subscription_client/subscriptions_controller_spec.rb
+++ b/spec/requests/subscription_client/subscriptions_controller_spec.rb
@@ -12,13 +12,13 @@ describe SubscriptionClient::SubscriptionsController do
     sign_in(user)
   end
 
-  it "#index" do
+  it "returns subscriptions" do
     get "/admin/plugins/subscription-client/subscriptions.json"
     expect(response.status).to eq(200)
     expect(response.parsed_body.size).to eq(1)
   end
 
-  it "#update" do
+  it "updates subscriptions" do
     stub_subscription_request(200, resource, { subscriptions: [] })
     post "/admin/plugins/subscription-client/subscriptions.json"
     expect(response.status).to eq(200)

--- a/spec/requests/subscription_client/suppliers_controller_spec.rb
+++ b/spec/requests/subscription_client/suppliers_controller_spec.rb
@@ -2,7 +2,8 @@
 require_relative '../../plugin_helper'
 
 describe SubscriptionClient::SuppliersController do
-  fab!(:user) { Fabricate(:user, admin: true) }
+  fab!(:admin) { Fabricate(:user, admin: true) }
+  fab!(:moderator) { Fabricate(:user, moderator: true) }
   fab!(:supplier) { Fabricate(:subscription_client_supplier) }
   fab!(:resource) { Fabricate(:subscription_client_resource, supplier: supplier) }
   let(:subscription_response) do
@@ -19,36 +20,98 @@ describe SubscriptionClient::SuppliersController do
     }
   end
 
-  before do
-    sign_in(user)
+  context "with admin" do
+    before do
+      sign_in(admin)
+    end
+
+    it "lists suppliers" do
+      get "/admin/plugins/subscription-client/suppliers.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body['suppliers'].size).to eq(1)
+      expect(response.parsed_body['suppliers'].first['name']).to eq(supplier.name)
+    end
+
+    it "authorizes" do
+      get "/admin/plugins/subscription-client/suppliers/authorize", params: { supplier_id: supplier.id }
+      expect(response.status).to eq(302)
+      expect(cookies[:user_api_request_id].present?).to eq(true)
+    end
+
+    it "handles authorization callbacks" do
+      request_id = cookies[:user_api_request_id] = SubscriptionClient::Authorization.request_id(supplier.id)
+      payload = generate_auth_payload(admin.id, request_id)
+      stub_subscription_request(200, resource, subscription_response)
+
+      get "/admin/plugins/subscription-client/suppliers/authorize/callback", params: { payload: payload }
+      expect(response).to redirect_to("/admin/plugins/subscription-client/subscriptions")
+
+      subscription = SubscriptionClientSubscription.find_by(resource_id: resource.id)
+      expect(subscription.present?).to eq(true)
+      expect(subscription.subscribed).to eq(true)
+    end
+
+    it "destroys authorizations" do
+      request_id = SubscriptionClient::Authorization.request_id(supplier.id)
+      payload = generate_auth_payload(admin.id, request_id)
+      SubscriptionClient::Authorization.process_response(request_id, payload)
+
+      delete "/admin/plugins/subscription-client/suppliers/authorize", params: { supplier_id: supplier.id }
+      expect(response.status).to eq(200)
+      expect(supplier.authorized?).to eq(false)
+    end
   end
 
-  it "#authorize" do
-    get "/admin/plugins/subscription-client/suppliers/authorize", params: { supplier_id: supplier.id }
-    expect(response.status).to eq(302)
-    expect(cookies[:user_api_request_id].present?).to eq(true)
-  end
+  context "with moderator allowed to manage subscriptions" do
+    before do
+      SiteSetting.subscription_client_allow_moderator_subscription_management = true
+      sign_in(moderator)
+    end
 
-  it "#authorize_callback" do
-    request_id = cookies[:user_api_request_id] = SubscriptionClient::Authorization.request_id(supplier.id)
-    payload = generate_auth_payload(user.id, request_id)
-    stub_subscription_request(200, resource, subscription_response)
+    it "doesnt allow access" do
+      get "/admin/plugins/subscription-client/suppliers.json"
+      expect(response.status).to eq(403)
+    end
 
-    get "/admin/plugins/subscription-client/suppliers/authorize/callback", params: { payload: payload }
-    expect(response).to redirect_to("/admin/plugins/subscription-client/subscriptions")
+    context "with subscription_client_allow_moderator_supplier_management enabled" do
+      before do
+        SiteSetting.subscription_client_allow_moderator_supplier_management = true
+      end
 
-    subscription = SubscriptionClientSubscription.find_by(resource_id: resource.id)
-    expect(subscription.present?).to eq(true)
-    expect(subscription.subscribed).to eq(true)
-  end
+      it "lists suppliers" do
+        get "/admin/plugins/subscription-client/suppliers.json"
+        expect(response.status).to eq(200)
+        expect(response.parsed_body['suppliers'].size).to eq(1)
+      end
 
-  it "#destroy" do
-    request_id = SubscriptionClient::Authorization.request_id(supplier.id)
-    payload = generate_auth_payload(user.id, request_id)
-    SubscriptionClient::Authorization.process_response(request_id, payload)
+      it "authorizes" do
+        get "/admin/plugins/subscription-client/suppliers/authorize", params: { supplier_id: supplier.id }
+        expect(response.status).to eq(302)
+        expect(cookies[:user_api_request_id].present?).to eq(true)
+      end
 
-    delete "/admin/plugins/subscription-client/suppliers/authorize", params: { supplier_id: supplier.id }
-    expect(response.status).to eq(200)
-    expect(supplier.authorized?).to eq(false)
+      it "handles authorization callbacks" do
+        request_id = cookies[:user_api_request_id] = SubscriptionClient::Authorization.request_id(supplier.id)
+        payload = generate_auth_payload(moderator.id, request_id)
+        stub_subscription_request(200, resource, subscription_response)
+
+        get "/admin/plugins/subscription-client/suppliers/authorize/callback", params: { payload: payload }
+        expect(response).to redirect_to("/admin/plugins/subscription-client/subscriptions")
+
+        subscription = SubscriptionClientSubscription.find_by(resource_id: resource.id)
+        expect(subscription.present?).to eq(true)
+        expect(subscription.subscribed).to eq(true)
+      end
+
+      it "destroys authorizations" do
+        request_id = SubscriptionClient::Authorization.request_id(supplier.id)
+        payload = generate_auth_payload(moderator.id, request_id)
+        SubscriptionClient::Authorization.process_response(request_id, payload)
+
+        delete "/admin/plugins/subscription-client/suppliers/authorize", params: { supplier_id: supplier.id }
+        expect(response.status).to eq(200)
+        expect(supplier.authorized?).to eq(false)
+      end
+    end
   end
 end

--- a/test/javascripts/acceptance/discourse-subscription-client-test.js.es6
+++ b/test/javascripts/acceptance/discourse-subscription-client-test.js.es6
@@ -9,28 +9,35 @@ import { click, visit } from "@ember/test-helpers";
 import fixtures from "../fixtures/subscription-client-fixtures";
 import { test } from "qunit";
 
-acceptance("Subscription Client - Cannot manage subscriptions", function (needs) {
-  needs.user({ can_manage_subscriptions: false, moderator: true });
-  needs.settings({ subscription_client_enabled: true });
+acceptance(
+  "Subscription Client - Cannot manage subscriptions",
+  function (needs) {
+    needs.user({ can_manage_subscriptions: false, moderator: true });
+    needs.settings({ subscription_client_enabled: true });
 
-  test("Does not show subscription elements", async function (assert) {
-    updateCurrentUser({ subscription_notice_count: 2 });
+    test("Does not show subscription elements", async function (assert) {
+      updateCurrentUser({ subscription_notice_count: 2 });
 
-    await visit("/");
+      await visit("/");
 
-    await pauseTest();
-    assert.ok(
-      !exists("#toggle-hamburger-menu .badge-notification.subscription-notice"),
-      "subscription notice badge does not show"
-    );
+      await pauseTest();
+      assert.ok(
+        !exists(
+          "#toggle-hamburger-menu .badge-notification.subscription-notice"
+        ),
+        "subscription notice badge does not show"
+      );
 
-    await click(".hamburger-dropdown");
-    assert.ok(
-      !exists(".subscription-notices .badge-notification.subscription-notice"),
-      "subscription notice item does not show"
-    );
-  });
-});
+      await click(".hamburger-dropdown");
+      assert.ok(
+        !exists(
+          ".subscription-notices .badge-notification.subscription-notice"
+        ),
+        "subscription notice item does not show"
+      );
+    });
+  }
+);
 
 acceptance("Subscription Client - Hamburger Menu", function (needs) {
   needs.user();
@@ -39,7 +46,7 @@ acceptance("Subscription Client - Hamburger Menu", function (needs) {
   test("Shows notice count", async function (assert) {
     updateCurrentUser({
       subscription_notice_count: 2,
-      can_manage_subscriptions: true
+      can_manage_subscriptions: true,
     });
 
     await visit("/");

--- a/test/javascripts/acceptance/discourse-subscription-client-test.js.es6
+++ b/test/javascripts/acceptance/discourse-subscription-client-test.js.es6
@@ -9,18 +9,41 @@ import { click, visit } from "@ember/test-helpers";
 import fixtures from "../fixtures/subscription-client-fixtures";
 import { test } from "qunit";
 
+acceptance("Subscription Client - Cannot manage subscriptions", function (needs) {
+  needs.user({ can_manage_subscriptions: false, moderator: true });
+  needs.settings({ subscription_client_enabled: true });
+
+  test("Does not show subscription elements", async function (assert) {
+    updateCurrentUser({ subscription_notice_count: 2 });
+
+    await visit("/");
+
+    await pauseTest();
+    assert.ok(
+      !exists("#toggle-hamburger-menu .badge-notification.subscription-notice"),
+      "subscription notice badge does not show"
+    );
+
+    await click(".hamburger-dropdown");
+    assert.ok(
+      !exists(".subscription-notices .badge-notification.subscription-notice"),
+      "subscription notice item does not show"
+    );
+  });
+});
+
 acceptance("Subscription Client - Hamburger Menu", function (needs) {
   needs.user();
   needs.settings({ subscription_client_enabled: true });
 
-  test("As a staff member with notices", async function (assert) {
+  test("Shows notice count", async function (assert) {
     updateCurrentUser({
-      moderator: true,
-      admin: false,
       subscription_notice_count: 2,
+      can_manage_subscriptions: true
     });
 
     await visit("/");
+
     assert.strictEqual(
       queryAll(
         "#toggle-hamburger-menu .badge-notification.subscription-notice"
@@ -39,7 +62,7 @@ acceptance("Subscription Client - Hamburger Menu", function (needs) {
 });
 
 acceptance("Subscription Client - Admin", function (needs) {
-  needs.user({ admin: false });
+  needs.user({ admin: true, can_manage_subscriptions: true });
   needs.settings({ subscription_client_enabled: true });
   needs.pretender((server, helper) => {
     server.get("/admin/plugins/subscription-client.json", () =>


### PR DESCRIPTION
@merefield This makes subscription management admin only by default. This is a request from a potential Custom Wizard subscriber and I think it makes sense to make it the default. 

The reason it wasn't the default in the first place is that Discourse's plugin system is available to moderators by default, e.g. if you use the `add_admin_route` server api function. The `Admin::PluginsController` inherits from `Admin::StaffController` not `Admin::AdminController`.

This is why this PR has an extension of `Admin::PluginsController`. However, query whether we should PR to `discourse/discourse` to make this a core functionality in the near future.

The alternative to using the `Admin::Plugins` route is to create a dedicated admin route like the Custom Wizard plugin, or Multilingual Plugins do. However `Admin::Plugins` feels like the natural place for this plugin, both from a UX perspective and a conceptual perspective, i.e. it's about subscriptions for other plugins.