### PR TITLE
Fix for redirect action path to take account of Discourse sub-directory base URL

### DIFF
--- a/assets/javascripts/discourse/models/subscription-client-supplier.js.es6
+++ b/assets/javascripts/discourse/models/subscription-client-supplier.js.es6
@@ -3,7 +3,8 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import EmberObject from "@ember/object";
 
 const SubscriptionClientSupplier = EmberObject.extend();
-const basePath = "/admin/plugins/subscription-client/suppliers";
+const baseUrl = window.location.href.split("/admin");
+const basePath = baseUrl + "/admin/plugins/subscription-client/suppliers";
 
 SubscriptionClientSupplier.reopenClass({
   list() {

--- a/assets/javascripts/discourse/models/subscription-client.js.es6
+++ b/assets/javascripts/discourse/models/subscription-client.js.es6
@@ -3,7 +3,8 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import EmberObject from "@ember/object";
 
 const SubscriptionClient = EmberObject.extend();
-const basePath = "/admin/plugins/subscription-client";
+const baseUrl = window.location.href.split("/admin");
+const basePath = baseUrl + "/admin/plugins/subscription-client";
 
 SubscriptionClient.reopenClass({
   show() {


### PR DESCRIPTION
A patch for `authorize` path to take account of Discourse deployments with subdirectory base URL i.e. www.discourse.com/foo/bar.

Currently it will try to go to URL only on the top level domain i.e. `www.discourse.com/authorize?supplier_id=1` where it should have included the subdirectories. i.e. `www.discourse.com/foo/bar/authorize?supplier_id=1`