### PR TITLE
Support subscription server products PR in isolation

### DIFF
--- a/app/models/subscription_client_subscription.rb
+++ b/app/models/subscription_client_subscription.rb
@@ -6,7 +6,12 @@ class SubscriptionClientSubscription < ActiveRecord::Base
 
   belongs_to :resource, class_name: "SubscriptionClientResource"
 
-  scope :active, -> { where("subscribed = true AND updated_at > ?", SubscriptionClientSubscription.update_period) }
+  scope :active, lambda {
+    where(
+      "subscription_client_subscriptions.subscribed = true AND
+       subscription_client_subscriptions.updated_at > ?", SubscriptionClientSubscription.update_period
+    )
+  }
 
   def active
     self.subscribed && updated_at.to_datetime > self.class.update_period.to_datetime

--- a/app/models/subscription_client_supplier.rb
+++ b/app/models/subscription_client_supplier.rb
@@ -19,6 +19,14 @@ class SubscriptionClientSupplier < ActiveRecord::Base
     api_key.present?
   end
 
+  def product_slugs(resource)
+    return {} unless products.present? && products[resource]
+
+    products[resource].each_with_object({}) do |product, result|
+      result[product["product_id"]] = product["product_slug"]
+    end
+  end
+
   def deactivate_all_subscriptions!
     subscriptions.update_all(subscribed: false)
   end
@@ -42,6 +50,7 @@ end
 #  authorized_at :datetime
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  products      :json
 #
 # Indexes
 #

--- a/db/migrate/20230504135449_add_products_to_subscription_client_suppliers.rb
+++ b/db/migrate/20230504135449_add_products_to_subscription_client_suppliers.rb
@@ -2,6 +2,6 @@
 
 class AddProductsToSubscriptionClientSuppliers < ActiveRecord::Migration[7.0]
   def change
-    add_column :subscription_client_suppliers, :products, :json
+    add_column :subscription_client_suppliers, :products, :json, if_not_exists: true
   end
 end

--- a/db/migrate/20230504135449_add_products_to_subscription_client_suppliers.rb
+++ b/db/migrate/20230504135449_add_products_to_subscription_client_suppliers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProductsToSubscriptionClientSuppliers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :subscription_client_suppliers, :products, :json
+  end
+end

--- a/lib/subscription_client/engine.rb
+++ b/lib/subscription_client/engine.rb
@@ -24,5 +24,23 @@ module ::SubscriptionClient
     else
       true
     end
+
+    def find_subscriptions(resource_name = nil)
+      return nil unless resource_name
+
+      subscriptions = SubscriptionClientSubscription.active
+        .includes(resource: [:supplier])
+        .references(resource: [:supplier])
+        .where("subscription_client_resources.name = ? ", resource_name)
+
+      result = SubscriptionClient::Subscriptions::Result.new
+      return result unless subscriptions.exists?
+
+      result.resource = subscriptions.first.resource
+      result.supplier = subscriptions.first.resource.supplier
+      result.subscriptions = subscriptions.to_a
+
+      result
+    end
   end
 end

--- a/lib/subscription_client/engine.rb
+++ b/lib/subscription_client/engine.rb
@@ -36,9 +36,15 @@ module ::SubscriptionClient
       result = SubscriptionClient::Subscriptions::Result.new
       return result unless subscriptions.exists?
 
-      result.resource = subscriptions.first.resource
-      result.supplier = subscriptions.first.resource.supplier
+      resource = subscriptions.first.resource
+      supplier = resource.supplier
+      products = supplier.product_slugs(resource_name)
+      return result unless products.present?
+
+      result.resource = resource
+      result.supplier = supplier
       result.subscriptions = subscriptions.to_a
+      result.products = products
 
       result
     end

--- a/lib/subscription_client/resources.rb
+++ b/lib/subscription_client/resources.rb
@@ -85,13 +85,12 @@ class SubscriptionClient::Resources
     Dir["#{SubscriptionClient.root}/plugins/*/plugin.rb"].sort.each do |path|
       source = File.read(path)
       metadata = Plugin::Metadata.parse(source)
+      next unless metadata.subscription_url.present?
 
-      if metadata.subscription_url.present?
-        @resources << {
-          name: metadata.name,
-          supplier_url: metadata.subscription_url
-        }
-      end
+      @resources << {
+        name: metadata.name,
+        supplier_url: ENV["TEST_SUBSCRIPTION_URL"] || metadata.subscription_url
+      }
     end
   end
 end

--- a/lib/subscription_client/resources.rb
+++ b/lib/subscription_client/resources.rb
@@ -41,21 +41,13 @@ class SubscriptionClient::Resources
     supplier_urls = @resources.map { |resource| resource[:supplier_url] }.uniq.compact
 
     supplier_urls.each do |url|
-      supplier = SubscriptionClientSupplier.find_by(url: url)
+      supplier = SubscriptionClientSupplier.find_or_create_by(url: url)
+      request = SubscriptionClient::Request.new(:supplier, supplier.id)
+      data = request.perform("#{url}/subscription-server")
 
-      if supplier && supplier.name
+      if valid_supplier_data?(data)
+        supplier.update(name: data[:supplier], products: data[:products])
         @suppliers << supplier
-      else
-        supplier = supplier || SubscriptionClientSupplier.create!(url: url)
-        request = SubscriptionClient::Request.new(:supplier, supplier.id)
-        data = request.perform("#{url}/subscription-server")
-
-        if data
-          supplier.update(name: data[:supplier])
-          @suppliers << supplier
-        else
-          supplier.destroy!
-        end
       end
     end
   end
@@ -91,6 +83,22 @@ class SubscriptionClient::Resources
         name: metadata.name,
         supplier_url: ENV["TEST_SUBSCRIPTION_URL"] || metadata.subscription_url
       }
+    end
+  end
+
+  def valid_supplier_data?(data)
+    return false unless data.present? && data.is_a?(Hash)
+    return false unless %i[supplier products].all? { |key| data.key?(key) }
+    return false unless data[:supplier].is_a?(String)
+    return false unless data[:products].is_a?(Hash)
+
+    data[:products].all? do |resource, products|
+      products.is_a?(Array) &&
+        products.all? do |product|
+          %i[product_id product_slug].all? do |key|
+            product.key?(key) && product[key].is_a?(String)
+          end
+        end
     end
   end
 end

--- a/lib/subscription_client/subscriptions.rb
+++ b/lib/subscription_client/subscriptions.rb
@@ -12,7 +12,7 @@ class SubscriptionClient::Subscriptions
   def update
     return if !SiteSetting.subscription_client_enabled
 
-    @result = SubscriptionClient::Subscriptions::Result.new
+    @result = SubscriptionClient::Subscriptions::UpdateResult.new
 
     if @suppliers.blank?
       @result.no_suppliers

--- a/lib/subscription_client/subscriptions/result.rb
+++ b/lib/subscription_client/subscriptions/result.rb
@@ -1,111 +1,15 @@
 # frozen_string_literal: true
 
-class ::SubscriptionClient::Subscriptions::Result
-  REQUIRED_KEYS ||= %i(
-    resource_id
-    product_id
-    price_id
-  )
-  OPTIONAL_KEYS ||= %i(
-    product_name
-    price_name
-  )
-  KEYS = REQUIRED_KEYS + OPTIONAL_KEYS
+module SubscriptionClient
+  class Subscriptions
+    class Result
+      attr_accessor :supplier,
+                    :resource,
+                    :subscriptions
 
-  attr_reader :errors,
-              :infos
-
-  def initialize
-    @errors = {}
-    @infos = {}
-  end
-
-  def not_authorized(supplier)
-    error("not_authorized", supplier)
-  end
-
-  def retrieve_subscriptions(supplier, raw_data)
-    unless raw_data[:subscriptions].is_a?(Array)
-      error("invalid_response", supplier)
-      return []
-    end
-
-    return [] if raw_data[:subscriptions].none?
-
-    subscriptions_data = raw_data[:subscriptions].compact
-
-    # subscriptions must be properly formed
-
-    subscriptions_data =
-      subscriptions_data
-        .map(&:symbolize_keys)
-        .each { |data| data[:resource_id] = data[:resource] }
-        .select { |data| REQUIRED_KEYS.all? { |key| data.has_key?(key) } }
-
-    # we only care about subscriptions for resources on this instance
-
-    resources = SubscriptionClientResource.where(
-      supplier_id: supplier.id,
-      name: subscriptions_data.map { |data| data[:resource] }
-    )
-
-    subscriptions_data.reduce([]) do |result, data|
-      resource = resources.select { |r| r.name === data[:resource] }.first
-      if resource.present?
-        data[:resource_id] = resource.id
-        result << OpenStruct.new(
-          required: data.slice(*REQUIRED_KEYS),
-          create: data.slice(*KEYS),
-          subscription: nil
-        )
-      else
-        info("no_resource", supplier, resource: data[:resource])
+      def any?
+        supplier.present? && resource.present? && subscriptions.present?
       end
-      result
     end
-  end
-
-  def connection_error(supplier)
-    error("supplier_connection", supplier)
-  end
-
-  def no_suppliers
-    info("no_suppliers")
-  end
-
-  def no_subscriptions(supplier)
-    info("no_subscriptions", supplier)
-  end
-
-  def updated_subscription(supplier, subscription_ids: nil)
-    info("updated_subscription", supplier, subscription_ids: subscription_ids)
-  end
-
-  def created_subscription(supplier, subscription_ids: nil)
-    info("created_subscription", supplier, subscription_ids: subscription_ids)
-  end
-
-  def failed_to_create_subscription(supplier, subscription_ids: nil)
-    info("failed_to_create_subscription", supplier, subscription_ids: subscription_ids)
-  end
-
-  def info(key, supplier = nil, subscription_ids: nil, resource: nil)
-    attrs = {}
-
-    if supplier
-      attrs = {
-        supplier: supplier.name,
-        supplier_url: supplier.url
-      }
-    end
-
-    attrs.merge!(subscription_ids) if subscription_ids.present?
-    attrs[:resource] if resource.present?
-
-    @infos[key] = I18n.t("subscription_client.subscriptions.info.#{key}", attrs)
-  end
-
-  def error(key, supplier)
-    @errors[key] = I18n.t("subscription_client.subscriptions.error.#{key}", supplier: supplier.name, supplier_url: supplier.url)
   end
 end

--- a/lib/subscription_client/subscriptions/result.rb
+++ b/lib/subscription_client/subscriptions/result.rb
@@ -5,10 +5,11 @@ module SubscriptionClient
     class Result
       attr_accessor :supplier,
                     :resource,
-                    :subscriptions
+                    :subscriptions,
+                    :products
 
       def any?
-        supplier.present? && resource.present? && subscriptions.present?
+        supplier.present? && resource.present? && subscriptions.present? && products.present?
       end
     end
   end

--- a/lib/subscription_client/subscriptions/update_result.rb
+++ b/lib/subscription_client/subscriptions/update_result.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+class ::SubscriptionClient::Subscriptions::UpdateResult
+  REQUIRED_KEYS ||= %i(
+    resource_id
+    product_id
+    price_id
+  )
+  OPTIONAL_KEYS ||= %i(
+    product_name
+    price_name
+  )
+  KEYS = REQUIRED_KEYS + OPTIONAL_KEYS
+
+  attr_reader :errors,
+              :infos
+
+  def initialize
+    @errors = {}
+    @infos = {}
+  end
+
+  def not_authorized(supplier)
+    error("not_authorized", supplier)
+  end
+
+  def retrieve_subscriptions(supplier, raw_data)
+    unless raw_data[:subscriptions].is_a?(Array)
+      error("invalid_response", supplier)
+      return []
+    end
+
+    return [] if raw_data[:subscriptions].none?
+
+    subscriptions_data = raw_data[:subscriptions].compact
+
+    # subscriptions must be properly formed
+
+    subscriptions_data =
+      subscriptions_data
+        .map(&:symbolize_keys)
+        .each { |data| data[:resource_id] = data[:resource] }
+        .select { |data| REQUIRED_KEYS.all? { |key| data.has_key?(key) } }
+
+    # we only care about subscriptions for resources on this instance
+
+    resources = SubscriptionClientResource.where(
+      supplier_id: supplier.id,
+      name: subscriptions_data.map { |data| data[:resource] }
+    )
+
+    subscriptions_data.reduce([]) do |result, data|
+      resource = resources.select { |r| r.name === data[:resource] }.first
+      if resource.present?
+        data[:resource_id] = resource.id
+        result << OpenStruct.new(
+          required: data.slice(*REQUIRED_KEYS),
+          create: data.slice(*KEYS),
+          subscription: nil
+        )
+      else
+        info("no_resource", supplier, resource: data[:resource])
+      end
+      result
+    end
+  end
+
+  def connection_error(supplier)
+    error("supplier_connection", supplier)
+  end
+
+  def no_suppliers
+    info("no_suppliers")
+  end
+
+  def no_subscriptions(supplier)
+    info("no_subscriptions", supplier)
+  end
+
+  def updated_subscription(supplier, subscription_ids: nil)
+    info("updated_subscription", supplier, subscription_ids: subscription_ids)
+  end
+
+  def created_subscription(supplier, subscription_ids: nil)
+    info("created_subscription", supplier, subscription_ids: subscription_ids)
+  end
+
+  def failed_to_create_subscription(supplier, subscription_ids: nil)
+    info("failed_to_create_subscription", supplier, subscription_ids: subscription_ids)
+  end
+
+  def info(key, supplier = nil, subscription_ids: nil, resource: nil)
+    attrs = {}
+
+    if supplier
+      attrs = {
+        supplier: supplier.name,
+        supplier_url: supplier.url
+      }
+    end
+
+    attrs.merge!(subscription_ids) if subscription_ids.present?
+    attrs[:resource] if resource.present?
+
+    @infos[key] = I18n.t("subscription_client.subscriptions.info.#{key}", attrs)
+  end
+
+  def error(key, supplier)
+    @errors[key] = I18n.t("subscription_client.subscriptions.error.#{key}", supplier: supplier.name, supplier_url: supplier.url)
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -23,6 +23,7 @@ after_initialize do
     ../lib/subscription_client/notices.rb
     ../lib/subscription_client/subscriptions.rb
     ../lib/subscription_client/subscriptions/result.rb
+    ../lib/subscription_client/subscriptions/update_result.rb
     ../app/models/subscription_client_notice.rb
     ../app/models/subscription_client_resource.rb
     ../app/models/subscription_client_subscription.rb

--- a/spec/components/subscription_client/engine_spec.rb
+++ b/spec/components/subscription_client/engine_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+describe SubscriptionClient do
+  let(:user) { Fabricate(:user) }
+  let!(:supplier) { Fabricate(:subscription_client_supplier) }
+  let!(:resource1) { Fabricate(:subscription_client_resource, supplier: supplier) }
+  let!(:resource2) { Fabricate(:subscription_client_resource, supplier: supplier) }
+
+  describe "#find_subscriptions" do
+    context "without a resource name" do
+      it "returns nil" do
+        result = SubscriptionClient.find_subscriptions
+        expect(result).to eq(nil)
+      end
+    end
+
+    context "without subscriptions" do
+      it "returns any empty result" do
+        result = SubscriptionClient.find_subscriptions(resource1.name)
+        expect(result.any?).to eq(false)
+      end
+    end
+
+    context "with subscriptions" do
+      let!(:subscription1) { Fabricate(:subscription_client_subscription, resource: resource1) }
+      let!(:subscription2) { Fabricate(:subscription_client_subscription, resource: resource1) }
+      let!(:subscription3) { Fabricate(:subscription_client_subscription, resource: resource2) }
+
+      it "returns the supplier, resource and subscriptions" do
+        result = SubscriptionClient.find_subscriptions(resource1.name)
+        expect(result.any?).to eq(true)
+        expect(result.supplier).to eq(supplier)
+        expect(result.resource).to eq(resource1)
+        expect(result.subscriptions).to contain_exactly(subscription1, subscription2)
+      end
+    end
+  end
+end

--- a/spec/components/subscription_client/resources_spec.rb
+++ b/spec/components/subscription_client/resources_spec.rb
@@ -3,25 +3,41 @@
 require_relative '../../plugin_helper'
 
 describe SubscriptionClient::Resources, type: :multisite do
+  let!(:supplier) { "Pavilion" }
+  let!(:products) { { "subscription-plugin": [{ product_id: "prod_CBTNpi3fqWWkq0", product_slug: "business" }] } }
+
   before do
     SubscriptionClient.stubs(:root).returns("#{Rails.root}/plugins/discourse-subscription-client/spec/fixtures")
   end
 
   it "finds all resources in all multisite instances" do
     test_multisite_connection("default") do
-      stub_server_request("https://coop.pavilion.tech", "Pavilion")
+      stub_server_request("https://coop.pavilion.tech", supplier: supplier, products: products)
       SubscriptionClient::Resources.find_all
 
-      expect(SubscriptionClientSupplier.exists?(name: "Pavilion")).to eq(true)
+      supplier = SubscriptionClientSupplier.find_by(name: "Pavilion")
+      expect(supplier.present?).to eq(true)
+      expect(supplier.products).to eq(products.as_json)
       expect(SubscriptionClientResource.exists?(name: "subscription-plugin")).to eq(true)
     end
 
     test_multisite_connection("second") do
-      stub_server_request("https://coop.pavilion.tech", "Pavilion")
+      stub_server_request("https://coop.pavilion.tech", supplier: supplier, products: products)
       SubscriptionClient::Resources.find_all
 
-      expect(SubscriptionClientSupplier.exists?(name: "Pavilion")).to eq(true)
+      supplier = SubscriptionClientSupplier.find_by(name: "Pavilion")
+      expect(supplier.present?).to eq(true)
+      expect(supplier.products).to eq(products.as_json)
       expect(SubscriptionClientResource.exists?(name: "subscription-plugin")).to eq(true)
     end
+  end
+
+  it "handles failed requests" do
+    stub_server_request("https://coop.pavilion.tech", status: 404)
+    SubscriptionClient::Resources.find_all
+
+    supplier = SubscriptionClientSupplier.find_by(name: "Pavilion")
+    expect(supplier.present?).to eq(false)
+    expect(SubscriptionClientResource.exists?(name: "subscription-plugin")).to eq(false)
   end
 end

--- a/spec/fabricators/subscription_client_resource_fabricator.rb
+++ b/spec/fabricators/subscription_client_resource_fabricator.rb
@@ -2,5 +2,5 @@
 
 Fabricator(:subscription_client_resource) do
   supplier(fabricator: :subscription_client_supplier)
-  name { "custom-wizard-plugin" }
+  name { sequence(:name) { |i| "resource-#{i}" } }
 end

--- a/spec/fabricators/subscription_client_resource_fabricator.rb
+++ b/spec/fabricators/subscription_client_resource_fabricator.rb
@@ -3,4 +3,15 @@
 Fabricator(:subscription_client_resource) do
   supplier(fabricator: :subscription_client_supplier)
   name { sequence(:name) { |i| "resource-#{i}" } }
+
+  after_create do |resource|
+    resource.supplier.products ||= {}
+    resource.supplier.products[resource.name] = [
+      {
+        product_id: "prod_CBTNpi3fqWWkq0",
+        product_slug: "business"
+      }
+    ]
+    resource.supplier.save!
+  end
 end

--- a/spec/jobs/subscription_client/update_subscriptions_spec.rb
+++ b/spec/jobs/subscription_client/update_subscriptions_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Jobs::SubscriptionClientUpdateSubscriptions do
-  let(:result) { SubscriptionClient::Subscriptions::Result.new }
+  let(:result) { SubscriptionClient::Subscriptions::UpdateResult.new }
 
   context "when the update succeeds" do
     before do

--- a/spec/models/subscription_client_supplier_spec.rb
+++ b/spec/models/subscription_client_supplier_spec.rb
@@ -29,4 +29,13 @@ describe SubscriptionClientSupplier do
       expect(subscription.subscribed).to eq(false)
     end
   end
+
+  describe "#product_slugs" do
+    it "maps product slugs" do
+      expect(supplier.product_slugs('subscription-plugin')).to eq({})
+      supplier.products = { "subscription-plugin": [{ "product_id": "prod_CBTNpi3fqWWkq0", "product_slug": "business" }] }.as_json
+      supplier.save!
+      expect(supplier.reload.product_slugs('subscription-plugin')).to eq({ "prod_CBTNpi3fqWWkq0" => "business" })
+    end
+  end
 end

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -23,8 +23,15 @@ def stub_subscription_request(status, resource, body)
   stub_request(:get, "#{url}/subscription-server/user-subscriptions?resources[]=#{resource.name}").to_return(status: status, body: body.to_json)
 end
 
-def stub_server_request(server_url, supplier, status = 200)
-  stub_request(:get, "#{server_url}/subscription-server").to_return(status: status, body: { supplier: supplier }.to_json)
+def stub_server_request(server_url, supplier: nil, products: [], status: 200)
+  body = {}
+  body[:supplier] = supplier if supplier.present?
+  body[:products] = products if products.present?
+
+  stub_request(:get, "#{server_url}/subscription-server").to_return(
+    status: status,
+    body: body.to_json
+  )
 end
 
 def stub_subscription_messages_request(supplier, status, messages)


### PR DESCRIPTION
Can only be merged once the following PRs are merged and live in production:
- https://github.com/paviliondev/discourse-subscription-server/pull/2

* Add products support to plugin client
* Retrieves product id and product level mapping from subscription server and keeps a local copy